### PR TITLE
ブログ投稿作成の保存処理実装/保存時入力チェック処理実装

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,11 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Models\Post;
-use Illuminate\Http\Request;
+use App\Http\Requests\PostRequest;
 
 class PostController extends Controller
 {
-    public function index(Post $post){
+    public function index(Post $post)
+    {
         return view('posts/index')->with(['posts' => $post->getPaginateByLimit()]);
     }
     public function show(Post $post)
@@ -17,6 +18,12 @@ class PostController extends Controller
     public function create()
     {
         return view('posts/create');
+    }
+    public function store(Post $post, PostRequest $request)
+    {
+        $input = $request['post'];
+        $post->fill($input)->save();
+        return redirect('/posts/' . $post->id);
     }
 }
 ?>

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'post.title' => 'required|string|max:100',
+            'post.body' => 'required|string|max:4000',
+        ];
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -8,7 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class Post extends Model
 {
     use HasFactory;
-    public function getPaginateByLimit(int $limit_count = 10){
+    
+    protected $fillable = [
+        'title',
+        'body',
+    ];
+    public function getPaginateByLimit(int $limit_count = 10)
+    {
         return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
     }
     

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -6,20 +6,20 @@
     </head>
     <body>
         <h1>Blog Name</h1>
-        <from action="/posts" method="POST">
+        <form action="/posts" method="POST">
             @csrf
             <div class="title">
                 <h2>Title</h2>
-                <input type="text" name="post[title]" placeholder="タイトル"/>
+                <input type="text" name="post[title]" placeholder="タイトル" value="{{ old('post.title') }}"/>
+                <p class="title__error" style="color:red">{{ $errors->first('post.title') }}</p>
             </div>
             <div class="body">
                 <h2>Body</h2>
-                <textarea name="post[body]" placeholder="今日も1日お疲れ様でした。"></textarea>
+                <textarea name="post[body]" placeholder="今日も1日お疲れ様でした。">{{ old('post.body') }}</textarea>
+                <p class="body__error" style="color:red">{{ $errors->first('post.body') }}</p>
             </div>
-            <input type="submit" value="store"/>
-        </from>
-        <div class="footer">
-            <a href="/">戻る</a>
-        </div>
+            <input type="submit" value="保存"/>
+        </form>
+        <div class="back">[<a href="/">back</a>]</div>
     </body>
 </html>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,17 +1,13 @@
 <!DOGTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getlocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
-        <title>
-            Blog
-        </title>
+        <title>Blog</title>
         <!-- Font -->
         <link herf="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
     </head>
     <body>
-        <h1>
-            Blog Name
-        </h1>
+        <h1>Blog Name</h1>
         <a href='/posts/create'>create</a>
         <div class='posts'>
              @foreach ($posts as $post)

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,9 +1,9 @@
 <!DOGTYPE HTML>
-<html lang="{{ str_replace('_','-',app()->getLocale()) }}">
+<html lang="{{ str_replace('_','-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>posts</title>
+        <title>Posts</title>
         <!-- Fonts -->
         <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
     </head>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,4 +16,5 @@ use App\Http\Controllers\PostController;
 Route::get('/', [PostController::class, 'index']);
 Route::get('/posts/create', [PostController::class, 'create']);
 Route::get('/posts/{post}', [PostController::class, 'show']);
+Route::post('/posts', [PostController::class, 'store']);
 ?>


### PR DESCRIPTION
ブログの投稿作成画面で、titleとbodyのテキストエリアに入力した文字を保存して、詳細画面に移行させるようにした。

titleかbodyのいずれか/両方を入力しないで保存をしたら、エラーメッセージを表示させるようにした。

